### PR TITLE
Resolved issue when '|' char is getting copied and extends CLI with new file types for code,data and model

### DIFF
--- a/client/constants.cs
+++ b/client/constants.cs
@@ -7,5 +7,13 @@ namespace Constants
     {
         internal const string RESOURCE_TYPE_HINT = "Resource Type: \"code\", \"data\" or \"model\"";
         internal const string APPLICATION_ALIAS = "nyoka";
+
+        internal const string HeaderStringType = " Type";
+        internal const string HeaderStringNameOfResource = " Name of Resource";
+        internal const string HeaderStringLatestVersion = " Latest Version";
+        internal const string HeaderStringLocalVersion = " Local Version";
+        internal const string HeaderStringFileSize = " File Size";
+        internal const string HeaderStringVersion = " Version";
+
     }
 }

--- a/client/fileTypeInference.cs
+++ b/client/fileTypeInference.cs
@@ -11,9 +11,9 @@ namespace FileTypeInferenceNS
             }
         }
 
-        public static readonly string[] codeFileExtensions = {"py", "ipynb", "r", "jar"};
-        public static readonly string[] modelFileExtensions = {"pmml"};
-        public static readonly string[] dataFileExtensions = {"json", "csv", "png", "jpg", "jpeg", "zip","txt","md"};
+        public static readonly string[] codeFileExtensions = {"py", "ipynb", "r", "jar", "mon"};
+        public static readonly string[] modelFileExtensions = {"pmml", "h5", "pb", "pbtxt", "onnx"};
+        public static readonly string[] dataFileExtensions = {"json", "csv", "png", "jpg", "jpeg", "zip","txt","md", "webp"};
 
         private static string getLowerCaseFileExtension(string fileName)
         {
@@ -42,6 +42,7 @@ namespace FileTypeInferenceNS
             case "ipynb":
             case "r":
             case "jar":
+            case "mon":
                 return true;
             default:
                 return false;
@@ -54,6 +55,10 @@ namespace FileTypeInferenceNS
             switch(extension)
             {
             case "pmml":
+            case "h5":
+            case "pb":
+            case "pbtxt":
+            case "onnx" :
                 return true;
             default:
                 return false;
@@ -73,6 +78,7 @@ namespace FileTypeInferenceNS
             case "zip":
             case "txt":
             case "md":
+            case "webp":
                 return true;
             default:
                 return false;

--- a/client/packageManager.cs
+++ b/client/packageManager.cs
@@ -389,7 +389,7 @@ namespace PackageManagerNS
                 }
 
                 CLIInterface.PrintTable table = new CLIInterface.PrintTable {
-                    {ConstStrings.HeaderStringType, 8},
+                    {ConstStrings.HeaderStringType, 6},
                     {ConstStrings.HeaderStringNameOfResource, 21},
                     {ConstStrings.HeaderStringVersion, 16},
                     {ConstStrings.HeaderStringFileSize, 11},
@@ -532,7 +532,7 @@ namespace PackageManagerNS
                     new List<ResourceType> { ResourceType.Code, ResourceType.Data, ResourceType.Model };
 
                 CLIInterface.PrintTable printTable = new CLIInterface.PrintTable {
-                    {ConstStrings.HeaderStringFileSize, 8},
+                    {ConstStrings.HeaderStringType, 6},
                     {ConstStrings.HeaderStringNameOfResource, 21},
                     {ConstStrings.HeaderStringLatestVersion, 16},
                     {ConstStrings.HeaderStringLocalVersion, 2},

--- a/client/packageManager.cs
+++ b/client/packageManager.cs
@@ -233,9 +233,9 @@ namespace PackageManagerNS
                     CLIInterface.PrintTable table = new CLIInterface.PrintTable {
                         {"Resource Type", 13},
                         {"Dependency Type", 15},
-                        {"Name of Resource", 15},
-                        {"Resource Version", 15},
-                        {"File Size", 10},
+                        {"Name of Resource", 16},
+                        {"Resource Version", 16},
+                        {"File Size", 9},
                     };
 
                     foreach (var (depResourceType, deps) in depDescriptions.Select(x => (x.Key, x.Value)))
@@ -389,10 +389,10 @@ namespace PackageManagerNS
                 }
 
                 CLIInterface.PrintTable table = new CLIInterface.PrintTable {
-                    {"Type", 7},
-                    {"Name of Resource", 20},
-                    {"Version", 15},
-                    {"File Size", 10},
+                    {ConstStrings.HeaderStringType, 8},
+                    {ConstStrings.HeaderStringNameOfResource, 21},
+                    {ConstStrings.HeaderStringVersion, 16},
+                    {ConstStrings.HeaderStringFileSize, 11},
                 };
 
                 List<ResourceType> resourcesToList = listType.HasValue ?
@@ -416,10 +416,10 @@ namespace PackageManagerNS
                         long fileSize = FSOps.getResourceSize(resourceType, resourceName);
 
                         table.addRow(
-                            resourceType.ToString(),
-                            resourceName,
-                            version,
-                            bytesToString(fileSize)
+                            doFormat(resourceType.ToString()),
+                            doFormat(resourceName),
+                            doFormat(version),
+                            doFormat(bytesToString(fileSize))
                         );
                     }
                 }
@@ -532,11 +532,11 @@ namespace PackageManagerNS
                     new List<ResourceType> { ResourceType.Code, ResourceType.Data, ResourceType.Model };
 
                 CLIInterface.PrintTable printTable = new CLIInterface.PrintTable {
-                    {"Type", 7},
-                    {"Name of Resource", 20},
-                    {"Latest Version", 15},
-                    {"Local Version", 1},
-                    {"File Size", 10},
+                    {ConstStrings.HeaderStringFileSize, 8},
+                    {ConstStrings.HeaderStringNameOfResource, 21},
+                    {ConstStrings.HeaderStringLatestVersion, 16},
+                    {ConstStrings.HeaderStringLocalVersion, 2},
+                    {ConstStrings.HeaderStringFileSize, 11},
                 };
 
                 foreach (ResourceType resourceType in resourcesToList)
@@ -564,11 +564,11 @@ namespace PackageManagerNS
                         }
 
                         printTable.addRow(
-                            resourceType.ToString(),
-                            resourceName,
-                            availableResources.resourceDescriptions[resourceName].versionStr,
-                            localVersionStr,
-                            bytesToString(availableResources.resourceDescriptions[resourceName].byteCount)
+                            doFormat(resourceType.ToString()),
+                            doFormat(resourceName),
+                            doFormat(availableResources.resourceDescriptions[resourceName].versionStr),
+                            doFormat(localVersionStr),
+                            doFormat(bytesToString(availableResources.resourceDescriptions[resourceName].byteCount))
                         );
                     }
                 }
@@ -697,5 +697,11 @@ namespace PackageManagerNS
                 CLIInterface.logError($"Network Error: {ex.Message}");
             }
         }
+
+        private static string doFormat(string input)
+        {
+            return ' ' + input + ' ';
+        }
     }
+    
 }


### PR DESCRIPTION
'list' and 'available' command show resource data in tabular format with '|' separate char.  
User often tries to copy resource name from listed resources to do further operation(s) like add or remove resource.  '|' is also getting copied along with resource name and so He/She often has to delete this annoying extra char.  Added white space chars format to resolve this issue.